### PR TITLE
fix(security): harden llm egress and enforce audit gates

### DIFF
--- a/.codex/verify.commands
+++ b/.codex/verify.commands
@@ -4,6 +4,7 @@ cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test
 cargo audit -D warnings
+pnpm -C ui audit --audit-level high
 pnpm -C ui lint
 pnpm -C ui test
 ./.codex/scripts/run_coverage.sh

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+* @saagar210
+
+# Security-critical control plane
+/.github/workflows/ @saagar210
+/.codex/ @saagar210
+/scripts/ci/ @saagar210
+/scripts/git/ @saagar210
+/.cargo/audit.toml @saagar210
+
+# Application security boundaries
+/src-tauri/ @saagar210
+/crates/applykit_core/ @saagar210
+/crates/applykit_llm/ @saagar210
+/crates/applykit_export/ @saagar210
+/ui/ @saagar210
+
+# Security and release governance docs
+/docs/security-*.md @saagar210
+/docs/release-*.md @saagar210
+/docs/post-launch-verification.md @saagar210

--- a/crates/applykit_core/src/config.rs
+++ b/crates/applykit_core/src/config.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -158,6 +159,58 @@ pub fn resolve_output_base(base_dir: &str) -> PathBuf {
     PathBuf::from(base_dir)
 }
 
+pub fn validate_local_llm_base_url(base_url: &str) -> anyhow::Result<()> {
+    let raw = base_url.trim();
+    if raw.is_empty() {
+        anyhow::bail!("llm base URL cannot be empty");
+    }
+
+    let (scheme, rest) =
+        raw.split_once("://").ok_or_else(|| anyhow::anyhow!("llm base URL must include scheme"))?;
+    if scheme != "http" && scheme != "https" {
+        anyhow::bail!("llm base URL must use http or https");
+    }
+
+    let authority = rest.split('/').next().unwrap_or_default();
+    if authority.is_empty() {
+        anyhow::bail!("llm base URL must include host");
+    }
+    if authority.contains('@') {
+        anyhow::bail!("llm base URL must not include userinfo");
+    }
+
+    let host = if authority.starts_with('[') {
+        let end = authority
+            .find(']')
+            .ok_or_else(|| anyhow::anyhow!("invalid IPv6 host format in llm base URL"))?;
+        let suffix = &authority[end + 1..];
+        if !suffix.is_empty() && !suffix.starts_with(':') {
+            anyhow::bail!("invalid host/port in llm base URL");
+        }
+        &authority[1..end]
+    } else {
+        authority.split(':').next().unwrap_or_default()
+    };
+
+    let host_lower = host.to_ascii_lowercase();
+    if host_lower == "localhost" {
+        return Ok(());
+    }
+
+    if let Ok(ipv4) = host.parse::<Ipv4Addr>() {
+        if ipv4.is_loopback() {
+            return Ok(());
+        }
+    }
+    if let Ok(ipv6) = host.parse::<Ipv6Addr>() {
+        if ipv6.is_loopback() {
+            return Ok(());
+        }
+    }
+
+    anyhow::bail!("llm base URL host must be loopback (localhost/127.0.0.0/8/::1)")
+}
+
 pub fn scoring_total_weights(scoring: &ScoringConfig) -> BTreeMap<&'static str, u8> {
     let mut map = BTreeMap::new();
     map.insert("role_match", scoring.role_match);
@@ -166,4 +219,41 @@ pub fn scoring_total_weights(scoring: &ScoringConfig) -> BTreeMap<&'static str, 
     map.insert("rigor_match", scoring.rigor_match);
     map.insert("signal_boost", scoring.signal_boost);
     map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_local_llm_base_url;
+
+    #[test]
+    fn validate_local_llm_base_url_accepts_loopback_hosts() {
+        let allowed = [
+            "http://localhost:11434",
+            "http://127.0.0.1:8080",
+            "http://127.10.20.30:9000",
+            "http://[::1]:11434",
+            "https://localhost",
+        ];
+        for url in allowed {
+            validate_local_llm_base_url(url).unwrap_or_else(|e| panic!("{url} should pass: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_local_llm_base_url_rejects_non_loopback_hosts() {
+        let userinfo_url = ["http://", "user", ":", "pass", "@localhost:11434"].concat();
+        let blocked = [
+            "",
+            "localhost:11434",
+            "ftp://localhost:21",
+            "http://0.0.0.0:11434",
+            "http://192.168.1.50:11434",
+            "https://example.com",
+            "https://8.8.8.8",
+        ];
+        for url in blocked {
+            assert!(validate_local_llm_base_url(url).is_err(), "{url} should fail");
+        }
+        assert!(validate_local_llm_base_url(&userinfo_url).is_err(), "{userinfo_url} should fail");
+    }
 }

--- a/crates/applykit_core/src/pipeline.rs
+++ b/crates/applykit_core/src/pipeline.rs
@@ -51,6 +51,8 @@ fn llm_rewrite(
     if !cfg.enabled || !task_allowed(cfg, task_name) {
         return Ok(None);
     }
+    crate::config::validate_local_llm_base_url(&cfg.base_url)
+        .context("llm base_url violates local-only policy")?;
 
     let request = LlmRequest { task, prompt: prompt.to_string() };
     let provider = cfg.provider.to_ascii_lowercase();

--- a/crates/applykit_core/src/tests.rs
+++ b/crates/applykit_core/src/tests.rs
@@ -603,6 +603,48 @@ Requirements:
         assert!(call_count.load(Ordering::SeqCst) > 0);
     }
 
+    #[test]
+    fn summarize_jd_with_non_loopback_base_url_falls_back_safely() {
+        let temp_repo = prepare_temp_repo();
+        let outdir = tempfile::tempdir().expect("tmp outdir");
+
+        save_runtime_settings(
+            temp_repo.path(),
+            &RuntimeSettings {
+                allow_unapproved: false,
+                llm_enabled: Some(true),
+                llm_provider: Some("lm_studio".to_string()),
+                llm_base_url: Some("https://example.com".to_string()),
+                llm_model: Some("local-model".to_string()),
+                llm_allowed_tasks: Some(vec!["summarize_jd".to_string()]),
+            },
+        )
+        .expect("save settings llm summarize");
+
+        let result = generate_packet(
+            GenerateInput {
+                company: "Acme".to_string(),
+                role: "Senior Support Engineer".to_string(),
+                source: "manual".to_string(),
+                baseline: Baseline::OnePage,
+                jd_text: fixture("jd_support_ops_01.txt"),
+                outdir: Some(outdir.path().to_path_buf()),
+                run_date: Some(NaiveDate::from_ymd_opt(2026, 2, 14).expect("date")),
+                track_override: None,
+                allow_unapproved: false,
+            },
+            GenerateOptions { repo_root: temp_repo.path().to_path_buf() },
+        )
+        .expect("generate with blocked base_url");
+
+        assert_eq!(result.extraction_source, ExtractionSource::Deterministic);
+        assert!(result.extraction_diagnostics.summarize_attempted);
+        assert!(result
+            .extraction_diagnostics
+            .summarize_fallback_reasons
+            .contains(&"request_failed".to_string()));
+    }
+
     proptest! {
         #[test]
         fn normalize_jd_is_idempotent(input in ".{0,2048}") {

--- a/crates/applykit_llm/src/lib.rs
+++ b/crates/applykit_llm/src/lib.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -26,6 +27,14 @@ pub trait LlmAdapter {
     fn rewrite(&self, req: &LlmRequest) -> anyhow::Result<LlmResponse>;
 }
 
+fn llm_http_client() -> anyhow::Result<Client> {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(20))
+        .build()
+        .context("building llm HTTP client")
+}
+
 #[derive(Debug, Clone)]
 pub struct OllamaAdapter {
     pub base_url: String,
@@ -45,7 +54,7 @@ impl LlmAdapter for OllamaAdapter {
             response: String,
         }
 
-        let client = Client::new();
+        let client = llm_http_client()?;
         let url = format!("{}/api/generate", self.base_url.trim_end_matches('/'));
         let resp = client
             .post(&url)
@@ -95,7 +104,7 @@ impl LlmAdapter for OpenAiCompatAdapter {
             content: String,
         }
 
-        let client = Client::new();
+        let client = llm_http_client()?;
         let url = format!("{}/v1/chat/completions", self.base_url.trim_end_matches('/'));
         let resp = client
             .post(&url)

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -122,6 +122,21 @@ Record for each run:
 - `decision`:
   - go (operational readiness posture unchanged; residual advisory risk accepted and tracked via closed AK-301/302/303 with reopen triggers)
 
+## Security Hardening Snapshot (2026-03-01)
+
+- `operator`: codex-session
+- `date_utc`: 2026-03-01T13:24:00Z
+- `git_ref`: working tree hardening cycle (pre-commit)
+- `verify_log_path`:
+  - `/tmp/applykit_security_hardening_verify_2026-03-01.log`
+- `security_audit_result`:
+  - canonical strict audit: pass
+  - baseline no-ignore scan: expected non-zero (`/tmp/applykit_security_baseline_2026-03-01.json`)
+  - UI dependency audit high: pass (`pnpm -C ui audit --audit-level high`)
+  - UI dependency audit moderate: pass (`pnpm -C ui audit --audit-level moderate`)
+- `decision`:
+  - go (hardening cycle complete; residual transitive Rust advisories remain tracked and time-bound)
+
 ## Golden Path
 1. `pnpm -C ui install --frozen-lockfile`
 2. `bash ./.codex/scripts/run_verify_commands.sh`

--- a/docs/security-advisory-tracking.md
+++ b/docs/security-advisory-tracking.md
@@ -108,3 +108,17 @@ Current posture:
   - active advisory IDs: 18
   - ignored advisory IDs in `.cargo/audit.toml`: 18
   - stale ignore IDs: none
+
+## 2026-03-01 Hardening Cycle Revalidation
+
+- Baseline command (no local ignore config):
+  - `cd /tmp && cargo audit -f /Users/d/Projects/ApplyKit/Cargo.lock -D warnings --json > /tmp/applykit_security_baseline_2026-03-01.json`
+  - Result: expected non-zero (`exit 1`) with informational warnings enabled.
+- Canonical strict audit:
+  - `cargo audit -D warnings`
+  - Result: pass.
+- Advisory drift check:
+  - active advisory IDs from baseline: 18
+  - ignore IDs in `.cargo/audit.toml`: 18
+  - stale ignore IDs: none
+  - missing ignore IDs: none

--- a/docs/security-hardening-cycle-2026-03-01.md
+++ b/docs/security-hardening-cycle-2026-03-01.md
@@ -1,0 +1,92 @@
+# Security Hardening Cycle Report (2026-03-01)
+
+## Scope
+
+This cycle executed remediation against previously identified risks:
+
+1. Unrestricted LLM egress endpoint configuration.
+2. Missing LLM network timeout controls.
+3. High-severity UI dependency advisories.
+4. Ownership gaps for security-critical files.
+
+## Verification Evidence
+
+| Command | Source | Result |
+| --- | --- | --- |
+| `bash ./.codex/scripts/run_verify_commands.sh` | `/Users/d/Projects/ApplyKit/.codex/verify.commands` | pass |
+| `cargo audit -D warnings` | `/Users/d/Projects/ApplyKit/.codex/verify.commands` | pass |
+| `cd /tmp && cargo audit -f /Users/d/Projects/ApplyKit/Cargo.lock -D warnings --json > /tmp/applykit_security_baseline_2026-03-01.json` | `/Users/d/Projects/ApplyKit/docs/week3-checklist.md` | expected fail (`exit 1`, informational warnings enabled) |
+| `pnpm -C ui audit --audit-level high` | `/Users/d/Projects/ApplyKit/.codex/verify.commands` | pass |
+| `pnpm -C ui audit --audit-level moderate` | ad-hoc hardening check | pass |
+| `node ./scripts/ci/check-ci-parity.mjs` | `/Users/d/Projects/ApplyKit/.codex/verify.commands` | pass |
+
+## Remediation Applied
+
+### Completed in this cycle
+
+1. Enforced local-only LLM endpoint policy.
+   - Files:
+     - `/Users/d/Projects/ApplyKit/crates/applykit_core/src/config.rs`
+     - `/Users/d/Projects/ApplyKit/crates/applykit_core/src/pipeline.rs`
+     - `/Users/d/Projects/ApplyKit/src-tauri/src/lib.rs`
+   - Outcome:
+     - LLM base URL now rejects non-loopback hosts and userinfo.
+     - Settings save path validates URL before persisting.
+     - Pipeline fails closed and uses deterministic fallback path when blocked.
+
+2. Added deterministic LLM HTTP timeout controls.
+   - File:
+     - `/Users/d/Projects/ApplyKit/crates/applykit_llm/src/lib.rs`
+   - Outcome:
+     - 5s connect timeout + 20s request timeout applied to adapters.
+
+3. Reduced UI dependency risk posture.
+   - File:
+     - `/Users/d/Projects/ApplyKit/pnpm-workspace.yaml`
+   - Outcome:
+     - Added workspace overrides for `rollup`, `minimatch`, and `ajv` vulnerable ranges.
+     - Current audit status: no high/moderate known vulnerabilities.
+
+4. Enforced ownership map for security-critical surfaces.
+   - File:
+     - `/Users/d/Projects/ApplyKit/.github/CODEOWNERS`
+   - Outcome:
+     - Security-sensitive paths now have explicit owner assignment.
+
+5. Added UI dependency-audit gate to canonical verify.
+   - Files:
+     - `/Users/d/Projects/ApplyKit/.codex/verify.commands`
+     - `/Users/d/Projects/ApplyKit/scripts/ci/check-ci-parity.mjs`
+   - Outcome:
+     - High-severity UI dependency advisories now block verification.
+
+## Prioritized Remediation Backlog (Open)
+
+| Priority | Risk | Current State | Owner | Target Date | Next Action |
+| --- | --- | --- | --- | --- | --- |
+| P0 | Rust transitive advisory residuals (`RUSTSEC-2024-0411` .. `0420`, `0429`, `0370`, `2025-0057`, `0075`, `0080`, `0081`, `0098`, `0100`) | still present in strict no-ignore baseline; no stale ignore IDs | applykit-platform | 2026-03-31 | Re-open AK-301/302/303 only when compatible `tauri/wry/tauri-utils` upgrade path becomes available and run full verify before removing any ignore entry |
+| P1 | UI supply-chain drift regression | high/moderate currently clear | applykit-platform | 2026-03-08 | Keep `pnpm -C ui audit --audit-level high` in blocking verify; promote `moderate` to weekly report-only monitor |
+| P1 | LLM egress policy bypass risk via future code paths | main pipeline and settings path protected | applykit-platform | 2026-03-15 | Add policy test coverage for all command entry points that consume runtime settings |
+| P2 | Security ownership single-point concentration | all ownership currently maps to one owner | applykit-platform | 2026-03-22 | Define backup reviewer for `.github/workflows`, `.cargo/audit.toml`, and `src-tauri` controls |
+
+## Ownership Map (Current)
+
+- Platform security owner: `applykit-platform`
+- Control plane:
+  - `/Users/d/Projects/ApplyKit/.github/workflows/`
+  - `/Users/d/Projects/ApplyKit/.codex/`
+  - `/Users/d/Projects/ApplyKit/scripts/ci/`
+- Application boundaries:
+  - `/Users/d/Projects/ApplyKit/src-tauri/`
+  - `/Users/d/Projects/ApplyKit/crates/applykit_core/`
+  - `/Users/d/Projects/ApplyKit/crates/applykit_llm/`
+  - `/Users/d/Projects/ApplyKit/ui/`
+- Security governance docs:
+  - `/Users/d/Projects/ApplyKit/docs/security-*.md`
+  - `/Users/d/Projects/ApplyKit/docs/release-*.md`
+
+## Closure Decision
+
+- Hardening cycle status: **complete** for previously identified actionable security gaps.
+- Residual risk status: **accepted and time-bound** for transitive Rust advisories pending compatible upstream dependency movement.
+- Next checkpoint: weekly security revalidation against baseline advisory JSON and canonical verify gates.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ajv@<6.14.0: 6.14.0
+  minimatch@<3.1.4: 3.1.4
+  minimatch@>=9.0.0 <9.0.7: 9.0.7
+  rollup@<4.59.0: 4.59.0
+
 importers:
 
   ui:
@@ -646,141 +652,141 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
-  '@rollup/rollup-android-arm-eabi@4.57.1':
-    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.57.1':
-    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.57.1':
-    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.57.1':
-    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.57.1':
-    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.57.1':
-    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
-    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
-    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.57.1':
-    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.57.1':
-    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.57.1':
-    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.57.1':
-    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
-    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.57.1':
-    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
-    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.57.1':
-    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.57.1':
-    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.57.1':
-    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.57.1':
-    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.57.1':
-    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.57.1':
-    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.57.1':
-    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.57.1':
-    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.57.1':
-    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.57.1':
-    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
 
@@ -968,8 +974,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1007,6 +1013,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -1017,8 +1027,9 @@ packages:
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -1395,11 +1406,11 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.4:
+    resolution: {integrity: sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+  minimatch@9.0.7:
+    resolution: {integrity: sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
@@ -1535,8 +1546,8 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
-  rollup@4.57.1:
-    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2064,7 +2075,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 3.1.2
+      minimatch: 3.1.4
     transitivePeerDependencies:
       - supports-color
 
@@ -2078,14 +2089,14 @@ snapshots:
 
   '@eslint/eslintrc@3.3.3':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -2292,79 +2303,79 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
-  '@rollup/rollup-android-arm-eabi@4.57.1':
+  '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.57.1':
+  '@rollup/rollup-android-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.57.1':
+  '@rollup/rollup-darwin-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.57.1':
+  '@rollup/rollup-darwin-x64@4.59.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.57.1':
+  '@rollup/rollup-freebsd-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.57.1':
+  '@rollup/rollup-freebsd-x64@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.57.1':
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.57.1':
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.57.1':
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.57.1':
+  '@rollup/rollup-linux-x64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.57.1':
+  '@rollup/rollup-openbsd-x64@4.59.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.57.1':
+  '@rollup/rollup-openharmony-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.57.1':
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.57.1':
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
@@ -2514,7 +2525,7 @@ snapshots:
       '@typescript-eslint/types': 8.55.0
       '@typescript-eslint/visitor-keys': 8.55.0
       debug: 4.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.7
       semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -2611,7 +2622,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv@6.12.6:
+  ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -2648,6 +2659,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.9.19: {}
 
   bidi-js@1.0.3:
@@ -2659,9 +2672,9 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
+  brace-expansion@5.0.4:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   browserslist@4.28.1:
     dependencies:
@@ -2817,7 +2830,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.12.6
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -2836,7 +2849,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
@@ -3054,13 +3067,13 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@3.1.2:
+  minimatch@3.1.4:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@9.0.5:
+  minimatch@9.0.7:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.4
 
   ms@2.1.3: {}
 
@@ -3172,35 +3185,35 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
-  rollup@4.57.1:
+  rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.57.1
-      '@rollup/rollup-android-arm64': 4.57.1
-      '@rollup/rollup-darwin-arm64': 4.57.1
-      '@rollup/rollup-darwin-x64': 4.57.1
-      '@rollup/rollup-freebsd-arm64': 4.57.1
-      '@rollup/rollup-freebsd-x64': 4.57.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
-      '@rollup/rollup-linux-arm64-gnu': 4.57.1
-      '@rollup/rollup-linux-arm64-musl': 4.57.1
-      '@rollup/rollup-linux-loong64-gnu': 4.57.1
-      '@rollup/rollup-linux-loong64-musl': 4.57.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
-      '@rollup/rollup-linux-ppc64-musl': 4.57.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
-      '@rollup/rollup-linux-riscv64-musl': 4.57.1
-      '@rollup/rollup-linux-s390x-gnu': 4.57.1
-      '@rollup/rollup-linux-x64-gnu': 4.57.1
-      '@rollup/rollup-linux-x64-musl': 4.57.1
-      '@rollup/rollup-openbsd-x64': 4.57.1
-      '@rollup/rollup-openharmony-arm64': 4.57.1
-      '@rollup/rollup-win32-arm64-msvc': 4.57.1
-      '@rollup/rollup-win32-ia32-msvc': 4.57.1
-      '@rollup/rollup-win32-x64-gnu': 4.57.1
-      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
   saxes@6.0.0:
@@ -3320,7 +3333,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.57.1
+      rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.10.13

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
 packages:
   - ui
+
+overrides:
+  "ajv@<6.14.0": 6.14.0
+  "minimatch@<3.1.4": 3.1.4
+  "minimatch@>=9.0.0 <9.0.7": 9.0.7
+  "rollup@<4.59.0": 4.59.0

--- a/scripts/ci/check-ci-parity.mjs
+++ b/scripts/ci/check-ci-parity.mjs
@@ -28,6 +28,7 @@ const checks = [
     file: ".codex/verify.commands",
     contains: [
       "node scripts/ci/check-ci-parity.mjs",
+      "pnpm -C ui audit --audit-level high",
       "./.codex/scripts/run_coverage.sh",
       "node ./.codex/scripts/check_diff_coverage.mjs",
       "node ./.codex/scripts/check_gate_waivers.mjs",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 use applykit_core::config::{
     load_config, load_runtime_settings, merge_config_with_runtime, resolve_output_base,
-    save_runtime_settings, RuntimeSettings,
+    save_runtime_settings, validate_local_llm_base_url, RuntimeSettings,
 };
 use applykit_core::insights::build_insights;
 use applykit_core::pipeline::{
@@ -832,11 +832,13 @@ fn get_settings_cmd() -> Result<SettingsResponse, String> {
 #[tauri::command]
 fn save_settings_cmd(input: SaveSettingsInput) -> Result<SettingsResponse, String> {
     let repo_root = repo_root()?;
+    let llm_base_url = required_trimmed_field("llmBaseUrl", input.llm_base_url)?;
+    validate_local_llm_base_url(&llm_base_url).map_err(|e| format!("invalid llmBaseUrl: {e}"))?;
     let runtime = RuntimeSettings {
         allow_unapproved: input.allow_unapproved,
         llm_enabled: Some(input.llm_enabled),
         llm_provider: Some(input.llm_provider),
-        llm_base_url: Some(input.llm_base_url),
+        llm_base_url: Some(llm_base_url),
         llm_model: Some(input.llm_model),
         llm_allowed_tasks: input.llm_allowed_tasks,
     };
@@ -1158,5 +1160,25 @@ allowed_tasks = []
         })
         .expect_err("invalid packet dir");
         assert!(err.contains("ReviewData.json"));
+    }
+
+    #[test]
+    fn save_settings_cmd_rejects_non_loopback_llm_base_url() {
+        let repo = tempfile::tempdir().expect("repo");
+        let base = repo.path().join("output_base");
+        std::fs::create_dir_all(&base).expect("create base");
+        write_test_config(repo.path(), &base);
+
+        let _cwd = CwdGuard::set_to(repo.path());
+        let err = save_settings_cmd(SaveSettingsInput {
+            allow_unapproved: false,
+            llm_enabled: true,
+            llm_provider: "ollama".to_string(),
+            llm_base_url: "https://example.com".to_string(),
+            llm_model: "llama3.2".to_string(),
+            llm_allowed_tasks: Some(vec!["rewrite_message".to_string()]),
+        })
+        .expect_err("non-loopback URL should fail");
+        assert!(err.contains("invalid llmBaseUrl"));
     }
 }


### PR DESCRIPTION
## What
- Enforced loopback-only LLM base URL policy in core pipeline and Tauri settings save path.
- Added deterministic HTTP timeouts for LLM adapters and regression coverage for blocked egress fallback paths.
- Added security ownership coverage via CODEOWNERS and published a 2026-03-01 hardening cycle report.
- Remediated UI dependency advisories with workspace overrides and added blocking `pnpm -C ui audit --audit-level high` to canonical verify.

## Why
- Previous audit findings flagged egress control gaps, timeout resilience gaps, and UI supply-chain exposure.
- This closes actionable hardening items while keeping residual transitive advisory risk explicitly time-bound and tracked.

## How
- Added URL validation helper in core config and reused it in pipeline + Tauri command layer.
- Replaced default reqwest blocking client creation with a configured timeout client.
- Updated verify contract and CI parity guard to keep UI high-severity audit mandatory.
- Updated security tracking and release runbook with current hardening evidence.

## Testing
- `bash ./.codex/scripts/run_verify_commands.sh` ✅
- `cargo audit -D warnings` ✅
- `pnpm -C ui audit --audit-level high` ✅
- `pnpm -C ui audit --audit-level moderate` ✅
- `node ./scripts/ci/check-ci-parity.mjs` ✅

## Lockfile rationale
- `pnpm-lock.yaml` changed because workspace-level security overrides were added in
  `/Users/d/Projects/ApplyKit/pnpm-workspace.yaml` for `rollup`, `minimatch`, and `ajv`.
- Lockfile resolution update is required to enforce patched transitive versions and keep UI
  dependency audit checks green in CI/local verify.

## Risk / Notes
- Residual Rust advisories remain transitive via upstream `tauri/wry/tauri-utils` chains and are
  tracked in `/Users/d/Projects/ApplyKit/docs/security-advisory-tracking.md`.
- Direct push to `main` is blocked by repo rules; this PR path preserves required checks.
